### PR TITLE
Allow SpeckleCoreGeometry to be a submodule of another project withou…

### DIFF
--- a/SpeckleCoreGeometryClasses/SpeckleCoreGeometryClasses.csproj
+++ b/SpeckleCoreGeometryClasses/SpeckleCoreGeometryClasses.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SpeckleCoreGeometryClasses/SpeckleCoreGeometryClasses.csproj
+++ b/SpeckleCoreGeometryClasses/SpeckleCoreGeometryClasses.csproj
@@ -49,7 +49,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\SpeckleCore\SpeckleCore\SpeckleCore.csproj">
+    <ProjectReference Include="$(SolutionDir)\SpeckleCore\SpeckleCore\SpeckleCore.csproj">
       <Project>{cfe27d3d-8a1a-43f9-9387-8fd9e119e174}</Project>
       <Name>SpeckleCore</Name>
     </ProjectReference>


### PR DESCRIPTION
Allow SpeckleCoreGeometry to be a submodule of another project without having to modify the path to Newtonsoft.Json.