### PR TITLE
Adds a check for null objects on NurbsCurve ToSpeckle

### DIFF
--- a/SpeckleCoreGeometryRhino/ConversionsGeometry.cs
+++ b/SpeckleCoreGeometryRhino/ConversionsGeometry.cs
@@ -377,8 +377,11 @@ namespace SpeckleCoreGeometryRhino
       if ( curve.IsLinear( Rhino.RhinoDoc.ActiveDoc.ModelAbsoluteTolerance ) || curve.IsPolyline() ) // defaults to polyline
       {
         Polyline getObj; curve.TryGetPolyline( out getObj );
-        SpeckleObject myObject = getObj.ToSpeckle(); myObject.Properties = properties; myObject.GenerateHash();
-        return myObject;
+        if (null != getObj)
+        {
+          SpeckleObject myObject = getObj.ToSpeckle(); myObject.Properties = properties; myObject.GenerateHash();
+          return myObject;
+        }
       }
 
       Polyline poly;


### PR DESCRIPTION
Some nurbs curves, even though they pass `curve.IsLinear`, fail to return a `Polyline` on`curve.TryGetPolyline()`. This left `getObj` null, which caused GH sender to hang on `          SpeckleObject myObject = getObj.ToSpeckle(); myObject.Properties = properties; myObject.GenerateHash();`

This PR checks that `getObj` is not null. If it's null, we use `curve.ToPolyline()` to get an approximation of the curve.
