### PR TITLE
Core non-prerelease

### DIFF
--- a/SpeckleCoreGeometry.sln
+++ b/SpeckleCoreGeometry.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.902
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29609.76
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpeckleCoreGeometry", "SpeckleCoreGeometry\SpeckleCoreGeometry.csproj", "{4E08BCAA-2B3A-4813-8B43-33B4AEDDF2FC}"
 EndProject

--- a/SpeckleCoreGeometryClasses/SpeckleCoreGeometryClasses.csproj
+++ b/SpeckleCoreGeometryClasses/SpeckleCoreGeometryClasses.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpeckleCore" Version="1.7.0-wip" />
+    <PackageReference Include="SpeckleCore" Version="1.7.2.414" />
   </ItemGroup>
 
 </Project>

--- a/SpeckleCoreGeometryClasses/SpeckleCoreGeometryClasses.nuspec
+++ b/SpeckleCoreGeometryClasses/SpeckleCoreGeometryClasses.nuspec
@@ -15,7 +15,7 @@
     <copyright>$copyright$</copyright>
     <tags>speckle core geometry</tags>
     <dependencies>
-      <dependency id="SpeckleCore" version="1.7.1" />
+      <dependency id="SpeckleCore" version="1.7.2" />
       <dependency id="Newtonsoft.Json" version="12.0.2" />
     </dependencies>
   </metadata>

--- a/SpeckleCoreGeometryDynamo/SpeckleCoreGeometryDynamo.csproj
+++ b/SpeckleCoreGeometryDynamo/SpeckleCoreGeometryDynamo.csproj
@@ -122,9 +122,8 @@
       <HintPath>..\packages\DynamoVisualProgramming.ZeroTouchLibrary.2.0.2.6986\lib\net45\ProtoGeometry.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SpeckleCore, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SpeckleCore.1.7.0-wip\lib\netstandard2.0\SpeckleCore.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="SpeckleCore, Version=1.7.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SpeckleCore.1.7.2.414\lib\netstandard2.0\SpeckleCore.dll</HintPath>
     </Reference>
     <Reference Include="SQLite-net, Version=1.5.231.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\sqlite-net-pcl.1.5.231\lib\netstandard1.1\SQLite-net.dll</HintPath>

--- a/SpeckleCoreGeometryDynamo/packages.config
+++ b/SpeckleCoreGeometryDynamo/packages.config
@@ -12,7 +12,7 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="NUnit" version="2.6.3" targetFramework="net461" />
   <package id="Prism" version="4.1.0.0" targetFramework="net461" />
-  <package id="SpeckleCore" version="1.7.0-wip" targetFramework="net461" />
+  <package id="SpeckleCore" version="1.7.2.414" targetFramework="net461" />
   <package id="sqlite-net-pcl" version="1.5.231" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.11" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.11" targetFramework="net461" />

--- a/SpeckleCoreGeometryRevit/SpeckleCoreGeometryRevit.csproj
+++ b/SpeckleCoreGeometryRevit/SpeckleCoreGeometryRevit.csproj
@@ -70,9 +70,8 @@
       <HintPath>..\packages\Revit.RevitApiUI.x64.2019.0.0\lib\net45\RevitAPIUI.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SpeckleCore, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SpeckleCore.1.7.0-wip\lib\netstandard2.0\SpeckleCore.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="SpeckleCore, Version=1.7.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SpeckleCore.1.7.2.414\lib\netstandard2.0\SpeckleCore.dll</HintPath>
     </Reference>
     <Reference Include="SQLite-net, Version=1.5.231.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\sqlite-net-pcl.1.5.231\lib\netstandard1.1\SQLite-net.dll</HintPath>

--- a/SpeckleCoreGeometryRevit/packages.config
+++ b/SpeckleCoreGeometryRevit/packages.config
@@ -8,7 +8,7 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Revit.RevitApi.x64" version="2019.0.0" targetFramework="net471" />
   <package id="Revit.RevitApiUI.x64" version="2019.0.0" targetFramework="net471" />
-  <package id="SpeckleCore" version="1.7.0-wip" targetFramework="net461" />
+  <package id="SpeckleCore" version="1.7.2.414" targetFramework="net461" />
   <package id="sqlite-net-pcl" version="1.5.231" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.11" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.11" targetFramework="net461" />

--- a/SpeckleCoreGeometryRhino/SpeckleCoreGeometryRhino.csproj
+++ b/SpeckleCoreGeometryRhino/SpeckleCoreGeometryRhino.csproj
@@ -78,9 +78,8 @@
       <HintPath>..\packages\RhinoCommon.6.12.19029.6381\lib\net45\RhinoCommon.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="SpeckleCore, Version=1.7.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SpeckleCore.1.7.0-wip\lib\netstandard2.0\SpeckleCore.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="SpeckleCore, Version=1.7.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SpeckleCore.1.7.2.414\lib\netstandard2.0\SpeckleCore.dll</HintPath>
     </Reference>
     <Reference Include="SQLite-net, Version=1.5.231.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\sqlite-net-pcl.1.5.231\lib\netstandard1.1\SQLite-net.dll</HintPath>

--- a/SpeckleCoreGeometryRhino/packages.config
+++ b/SpeckleCoreGeometryRhino/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="RhinoCommon" version="6.12.19029.6381" targetFramework="net461" />
-  <package id="SpeckleCore" version="1.7.0-wip" targetFramework="net461" />
+  <package id="SpeckleCore" version="1.7.2.414" targetFramework="net461" />
   <package id="sqlite-net-pcl" version="1.5.231" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.11" targetFramework="net461" />
   <package id="SQLitePCLRaw.core" version="1.1.11" targetFramework="net461" />


### PR DESCRIPTION
move core to non-pre-release version to handle references properly down the line (ie, speckle elements)