### PR TITLE
created afterbuilt routine

### DIFF
--- a/SpeckleCoreGeometry/SpeckleCoreGeometry.csproj
+++ b/SpeckleCoreGeometry/SpeckleCoreGeometry.csproj
@@ -99,4 +99,11 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
+    <!-- if we are in DEBUG mode, it copies built files to SpeckleKits user folder -->
+  <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Debug' ">
+    <ItemGroup>
+      <BuildFiles Include="$(TargetDir)\*.*" />
+    </ItemGroup>
+    <Copy SourceFiles="@(BuildFiles)" DestinationFolder="$(LocalAppData)\SpeckleKits\$(ProjectName)" />
+  </Target>
 </Project>


### PR DESCRIPTION
When SpeckleCoreGeometry solution is built, the entire result is copied into `%localappdata%\SpeckleKits`

This fixes the error that appears when trying to debug SpeckleRhino and SpeckleKits folder is missing.

**notes:**\
It works in Debug mode only.